### PR TITLE
allow more ssh keys algorithms

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -9,19 +9,7 @@ jobs:
   update_release_draft:
     runs-on: ubuntu-latest
     steps:
-      - name: Get application token to enable read access to EMnify repositories
-        id: get_token
-        uses: machine-learning-apps/actions-app-token@master
-        with:
-          APP_PEM: ${{ secrets.EMNIFY_GITHUB_ACTIONS_APP_PEM }}
-          APP_ID: ${{ secrets.EMNIFY_GITHUB_ACTIONS_APP_ID }}
-      - name: calculate next version
-        id: version
-        uses: patrickjahns/version-drafter-action@v1
+      # Drafts your next Release notes as Pull Requests are merged into "master"
+      - uses: release-drafter/release-drafter@v5.16.1
         env:
-          GITHUB_TOKEN: ${{ steps.get_token.outputs.app_token }}
-      - uses: release-drafter/release-drafter@v5
-        env:
-          GITHUB_TOKEN: ${{ steps.get_token.outputs.app_token }}
-        with:
-          version: ${{ steps.version.outputs.next-version }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/pkg/collector/ssh.go
+++ b/pkg/collector/ssh.go
@@ -10,6 +10,21 @@ import (
 )
 
 // copy from ssh exporter by Nordstrom (https://github.com/Nordstrom/ssh_exporter)
+var allowedHostKeyTypes = []string{
+	"ssh-rsa-cert-v01@openssh.com",
+	"ssh-dss-cert-v01@openssh.com",
+	"ecdsa-sha2-nistp256-cert-v01@openssh.com",
+	"ecdsa-sha2-nistp384-cert-v01@openssh.com",
+	"ecdsa-sha2-nistp521-cert-v01@openssh.com",
+	"ssh-ed25519-cert-v01@openssh.com",
+	"ecdsa-sha2-nistp256 ecdsa-sha2-nistp384",
+	"ecdsa-sha2-nistp521",
+	"ssh-rsa",
+	"ssh-dss",
+	"ssh-ed25519",
+	"rsa-sha2-256",
+	"rsa-sha2-512",
+}
 
 //
 // SoftCheck logs non-nil errors to stderr. Used for runtime errors that should
@@ -63,7 +78,8 @@ func (d *SpuMetricsDaemon) sshConnectToHost(host, port, user, keyfile string) (*
 		Auth: []ssh.AuthMethod{
 			ssh.PublicKeys(key),
 		},
-		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+		HostKeyCallback:   ssh.InsecureIgnoreHostKey(),
+		HostKeyAlgorithms: allowedHostKeyTypes,
 	}
 	sshConfig.SetDefaults()
 


### PR DESCRIPTION
The rsa-sha2-512 was removed from the defaults, but is used by the server

`
 level=error ts=2022-05-16T19:01:00.093481313Z caller=daemon.go:57 Failedtoexecutessh:%s="ssh: handshake failed: ssh: no common algorithm for host key; client offered: [ssh-rsa-cert-v01@openssh.com ssh-dss-cert-v01@openssh.com ecdsa-sha2-nistp256-cert-v01@openssh.com ecdsa-sha2-nistp384-cert-v01@openssh.com ecdsa-sha2-nistp521-cert-v01@openssh.com ssh-ed25519-cert-v01@openssh.com ecdsa-sha2-nistp256 ecdsa-sha2-nistp384 ecdsa-sha2-nistp521 ssh-rsa ssh-dss ssh-ed25519], server offered: [rsa-sha2-256 rsa-sha2-512]"
`