### PR TITLE
lock go version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '^1.14.1'
+          go-version: '>=1.17 <1.18'
       - name: Set VERSION env
         run: echo VERSION=$(echo ${GITHUB_REF} | rev | cut -d'/' -f 1 | rev ) >> $GITHUB_ENV
       - name: Build artifacts


### PR DESCRIPTION
broken for 1.18 on darwin (MacOS)