### PR TITLE
ignore ssh exit missing error

### DIFF
--- a/pkg/collector/ssh.go
+++ b/pkg/collector/ssh.go
@@ -33,8 +33,15 @@ var allowedHostKeyTypes = []string{
 func (d *SpuMetricsDaemon) SoftCheck(e error) bool {
 
 	if e != nil {
-		_ = level.Warn(d.logger).Log("message", "Error in ssh connection to spu application", "error", e)
-		return true
+		switch e.(type) {
+		case *ssh.ExitMissingError:
+			// ignore this error, just log on debug, happens just on ubuntu 14
+			level.Debug(d.logger).Log("ExitMissingError", "error", e)
+			return false
+		default:
+			_ = level.Warn(d.logger).Log("message", "Error in ssh connection to spu application", "error", e)
+			return true
+		}
 	}
 	return false
 }


### PR DESCRIPTION
On ubuntu 14 ssh is not exiting the session correctly, still we get all the data, so we can ignore this error.