### PR TITLE
fix parsing of server mode transports

### DIFF
--- a/pkg/collector/parser.go
+++ b/pkg/collector/parser.go
@@ -9,7 +9,7 @@ import (
 )
 
 var StringFind = regexp.MustCompile(`\s*([a-z-]+) "?([a-zA-Z0-9-\.]+)"?`)
-var IntFind = regexp.MustCompile(`\s*([a-z-]+)\s(\d+)$`)
+var IntFind = regexp.MustCompile(`\s*([a-z-]+)\s(\d+)(\s{)*$`)
 
 func parseLines(lines []string) ([]transport.Transport, error) {
 	transportPattern := regexp.MustCompile(`transport (\d+)`)
@@ -94,7 +94,6 @@ func ParseTransport(t *transport.Transport, line string) {
 		asdf := regexp.MustCompile("[a-z-]+")
 		match := asdf.FindStringSubmatch(line)
 		if match != nil {
-
 			t.LastKey = match[0]
 		}
 	}

--- a/pkg/transport/transport.go
+++ b/pkg/transport/transport.go
@@ -37,7 +37,7 @@ func NewPeer(number int64) Peer {
 }
 
 type State struct {
-	// can be okay, waiting and down
+	// can be okay, waiting, down and initial
 	Name   string
 	Number int
 }


### PR DESCRIPTION
regex was not getting peer for server mode

```
  server {
    accept {
    }
    peer 0 {
```