### PR TITLE
CN-4255: improve spu exporter to work with servers with multiple peers

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -21,6 +21,6 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.45.2
+          version: v1.52.2
 #      - name: Build release type artifacts
 #        run: make release

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -14,9 +14,9 @@ jobs:
       - name: Tests
         run: |
           make build
+          make test
 #          make fmt
 #          make vet
-          make test
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -16,7 +16,7 @@ jobs:
           make build
 #          make fmt
 #          make vet
-#          make test
+          make test
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@
 coverage.out
 /bin
 /dist
+goverage
+gox

--- a/Makefile
+++ b/Makefile
@@ -57,16 +57,14 @@ lint:
 
 .PHONY: test
 test:
-	@which goverage > /dev/null; if [ $$? -ne 0 ]; then \
-		GO111MODULE=off $(GO) get -u github.com/haya14busa/goverage; \
-	fi
-	goverage -v -coverprofile coverage.out $(PACKAGES)
+	GOBIN="$(PWD)" $(GO) install github.com/haya14busa/goverage@latest
+	./goverage -v -coverprofile coverage.out $(PACKAGES)
 
 .PHONY: build
 build: $(BIN)/$(EXECUTABLE)
 
 $(BIN)/$(EXECUTABLE): $(SOURCES)
-	$(GO) build -i -v -tags '$(TAGS)' -ldflags '$(LDFLAGS)' -o $@ .
+	$(GO) build -v -tags '$(TAGS)' -ldflags '$(LDFLAGS)' -o $@ .
 
 .PHONY: release
 release: release-dirs release-build release-checksums
@@ -77,10 +75,8 @@ release-dirs:
 
 .PHONY: release-build
 release-build:
-	@which gox > /dev/null; if [ $$? -ne 0 ]; then \
-		GO111MODULE=off  $(GO) get -u github.com/mitchellh/gox; \
-	fi
-	gox  -os="linux darwin" -arch="amd64" -verbose -ldflags '-w $(LDFLAGS)' -output="$(DIST)/$(EXECUTABLE)-{{.OS}}-{{.Arch}}" .
+	GOBIN="$(PWD)" $(GO) install github.com/mitchellh/gox@latest
+	./gox  -os="linux darwin" -arch="amd64" -verbose -ldflags '-w $(LDFLAGS)' -output="$(DIST)/$(EXECUTABLE)-{{.OS}}-{{.Arch}}" .
 
 .PHONY: release-checksums
 release-checksums:

--- a/pkg/collector/parser.go
+++ b/pkg/collector/parser.go
@@ -56,9 +56,9 @@ func ParseTransport(t *transport.Transport, line string) {
 		case "receive-buffer":
 			t.ReceiveBuffer = val
 		case "peer":
-		  if t.CurrentPeer.Number != nil {
-		    t.Peers = append(t.Peers, t.CurrentPeer)
-		  }
+			if t.CurrentPeer.Number != nil {
+				 t.Peers = append(t.Peers, t.CurrentPeer)
+			}
 			t.CurrentPeer = transport.NewPeer(val)
 		case "local-port":
 			t.LocalPort = val

--- a/pkg/collector/parser.go
+++ b/pkg/collector/parser.go
@@ -56,8 +56,10 @@ func ParseTransport(t *transport.Transport, line string) {
 		case "receive-buffer":
 			t.ReceiveBuffer = val
 		case "peer":
+		  if t.CurrentPeer.Number != nil {
+		    t.Peers = append(t.Peers, t.CurrentPeer)
+		  }
 			t.CurrentPeer = transport.NewPeer(val)
-			//t.Peers = append(t.Peers, t.CurrentPeer)
 		case "local-port":
 			t.LocalPort = val
 		}

--- a/pkg/collector/parser.go
+++ b/pkg/collector/parser.go
@@ -57,7 +57,7 @@ func ParseTransport(t *transport.Transport, line string) {
 			t.ReceiveBuffer = val
 		case "peer":
 			if t.CurrentPeer.Number != nil {
-				 t.Peers = append(t.Peers, t.CurrentPeer)
+				t.Peers = append(t.Peers, t.CurrentPeer)
 			}
 			t.CurrentPeer = transport.NewPeer(val)
 		case "local-port":

--- a/pkg/collector/ssh.go
+++ b/pkg/collector/ssh.go
@@ -26,10 +26,8 @@ var allowedHostKeyTypes = []string{
 	"rsa-sha2-512",
 }
 
-//
 // SoftCheck logs non-nil errors to stderr. Used for runtime errors that should
 // not kill the server.
-//
 func (d *SpuMetricsDaemon) SoftCheck(e error) bool {
 
 	if e != nil {
@@ -46,9 +44,7 @@ func (d *SpuMetricsDaemon) SoftCheck(e error) bool {
 	return false
 }
 
-//
 // executeScriptOnHost executes a given script on a given host.
-//
 func (d *SpuMetricsDaemon) executeScriptOnHost(host, port, user, keyfile, script string) (string, int, error) {
 
 	client, session, err := d.sshConnectToHost(host, port, user, keyfile)
@@ -72,9 +68,7 @@ func (d *SpuMetricsDaemon) executeScriptOnHost(host, port, user, keyfile, script
 
 }
 
-//
 // sshConnectToHost connects to a given host with the given keyfile.
-//
 func (d *SpuMetricsDaemon) sshConnectToHost(host, port, user, keyfile string) (*ssh.Client, *ssh.Session, error) {
 
 	key, err := d.getKeyFile(keyfile)
@@ -104,9 +98,7 @@ func (d *SpuMetricsDaemon) sshConnectToHost(host, port, user, keyfile string) (*
 	return client, session, nil
 }
 
-//
 // getKeyFile provides an ssh.Signer for the given keyfile (path to a private key).
-//
 func (d *SpuMetricsDaemon) getKeyFile(keyfile string) (ssh.Signer, error) {
 
 	buf, err := ioutil.ReadFile(keyfile)
@@ -122,11 +114,9 @@ func (d *SpuMetricsDaemon) getKeyFile(keyfile string) (ssh.Signer, error) {
 	return key, nil
 }
 
-//
 // literalFormat formats a string to be included in an endpoint to be scraped by Prometheus.
 //
 // Turns newline characters into '\n' characters.
-//
 func literalFormat(input string) string {
 	s1 := strings.Replace(input, "\r\n", "\\n", -1)
 	return strings.Replace(s1, "\n", "\\n", -1)

--- a/pkg/prom/prom.go
+++ b/pkg/prom/prom.go
@@ -27,7 +27,7 @@ var (
 
 func RegisterMetrics(reg *prometheus.Registry) {
 
-	labels := []string{"transport", "origin_host", "destination_host", "remote_ip"}
+	labels := []string{"peer", "transport", "origin_host", "destination_host", "remote_ip"}
 	state = promauto.NewGaugeVec(prometheus.GaugeOpts{Name: "spu_transport_state", Help: "State of the transport (labels okay, waiting, down with 1 or 0)"}, append(labels, "state"))
 	reg.MustRegister(state)
 
@@ -53,38 +53,38 @@ func CreateMetricLines(ts *[]transport.Transport, reg *prometheus.Registry) *pro
 			for _, p := range t.Peers {
 				switch p.State.Name {
 				case "okay":
-					state.WithLabelValues(strconv.FormatInt(*t.Number, 10), t.OriginHost, p.DestinationHost, p.RemoteIP, "okay").Set(1)
-					state.WithLabelValues(strconv.FormatInt(*t.Number, 10), t.OriginHost, p.DestinationHost, p.RemoteIP, "waiting").Set(0)
-					state.WithLabelValues(strconv.FormatInt(*t.Number, 10), t.OriginHost, p.DestinationHost, p.RemoteIP, "down").Set(0)
-					state.WithLabelValues(strconv.FormatInt(*t.Number, 10), t.OriginHost, p.DestinationHost, p.RemoteIP, "initial").Set(0)
+					state.WithLabelValues(strconv.FormatInt(*p.Number, 10), strconv.FormatInt(*t.Number, 10), t.OriginHost, p.DestinationHost, p.RemoteIP, "okay").Set(1)
+					state.WithLabelValues(strconv.FormatInt(*p.Number, 10), strconv.FormatInt(*t.Number, 10), t.OriginHost, p.DestinationHost, p.RemoteIP, "waiting").Set(0)
+					state.WithLabelValues(strconv.FormatInt(*p.Number, 10), strconv.FormatInt(*t.Number, 10), t.OriginHost, p.DestinationHost, p.RemoteIP, "down").Set(0)
+					state.WithLabelValues(strconv.FormatInt(*p.Number, 10), strconv.FormatInt(*t.Number, 10), t.OriginHost, p.DestinationHost, p.RemoteIP, "initial").Set(0)
 				case "waiting":
-					state.WithLabelValues(strconv.FormatInt(*t.Number, 10), t.OriginHost, p.DestinationHost, p.RemoteIP, "okay").Set(0)
-					state.WithLabelValues(strconv.FormatInt(*t.Number, 10), t.OriginHost, p.DestinationHost, p.RemoteIP, "waiting").Set(1)
-					state.WithLabelValues(strconv.FormatInt(*t.Number, 10), t.OriginHost, p.DestinationHost, p.RemoteIP, "down").Set(0)
-					state.WithLabelValues(strconv.FormatInt(*t.Number, 10), t.OriginHost, p.DestinationHost, p.RemoteIP, "initial").Set(0)
+					state.WithLabelValues(strconv.FormatInt(*p.Number, 10), strconv.FormatInt(*t.Number, 10), t.OriginHost, p.DestinationHost, p.RemoteIP, "okay").Set(0)
+					state.WithLabelValues(strconv.FormatInt(*p.Number, 10), strconv.FormatInt(*t.Number, 10), t.OriginHost, p.DestinationHost, p.RemoteIP, "waiting").Set(1)
+					state.WithLabelValues(strconv.FormatInt(*p.Number, 10), strconv.FormatInt(*t.Number, 10), t.OriginHost, p.DestinationHost, p.RemoteIP, "down").Set(0)
+					state.WithLabelValues(strconv.FormatInt(*p.Number, 10), strconv.FormatInt(*t.Number, 10), t.OriginHost, p.DestinationHost, p.RemoteIP, "initial").Set(0)
 				case "down":
-					state.WithLabelValues(strconv.FormatInt(*t.Number, 10), t.OriginHost, p.DestinationHost, p.RemoteIP, "okay").Set(0)
-					state.WithLabelValues(strconv.FormatInt(*t.Number, 10), t.OriginHost, p.DestinationHost, p.RemoteIP, "waiting").Set(0)
-					state.WithLabelValues(strconv.FormatInt(*t.Number, 10), t.OriginHost, p.DestinationHost, p.RemoteIP, "down").Set(1)
-					state.WithLabelValues(strconv.FormatInt(*t.Number, 10), t.OriginHost, p.DestinationHost, p.RemoteIP, "initial").Set(0)
+					state.WithLabelValues(strconv.FormatInt(*p.Number, 10), strconv.FormatInt(*t.Number, 10), t.OriginHost, p.DestinationHost, p.RemoteIP, "okay").Set(0)
+					state.WithLabelValues(strconv.FormatInt(*p.Number, 10), strconv.FormatInt(*t.Number, 10), t.OriginHost, p.DestinationHost, p.RemoteIP, "waiting").Set(0)
+					state.WithLabelValues(strconv.FormatInt(*p.Number, 10), strconv.FormatInt(*t.Number, 10), t.OriginHost, p.DestinationHost, p.RemoteIP, "down").Set(1)
+					state.WithLabelValues(strconv.FormatInt(*p.Number, 10), strconv.FormatInt(*t.Number, 10), t.OriginHost, p.DestinationHost, p.RemoteIP, "initial").Set(0)
 				case "initial":
-					state.WithLabelValues(strconv.FormatInt(*t.Number, 10), t.OriginHost, p.DestinationHost, p.RemoteIP, "okay").Set(0)
-					state.WithLabelValues(strconv.FormatInt(*t.Number, 10), t.OriginHost, p.DestinationHost, p.RemoteIP, "waiting").Set(0)
-					state.WithLabelValues(strconv.FormatInt(*t.Number, 10), t.OriginHost, p.DestinationHost, p.RemoteIP, "down").Set(0)
-					state.WithLabelValues(strconv.FormatInt(*t.Number, 10), t.OriginHost, p.DestinationHost, p.RemoteIP, "initial").Set(1)
+					state.WithLabelValues(strconv.FormatInt(*p.Number, 10), strconv.FormatInt(*t.Number, 10), t.OriginHost, p.DestinationHost, p.RemoteIP, "okay").Set(0)
+					state.WithLabelValues(strconv.FormatInt(*p.Number, 10), strconv.FormatInt(*t.Number, 10), t.OriginHost, p.DestinationHost, p.RemoteIP, "waiting").Set(0)
+					state.WithLabelValues(strconv.FormatInt(*p.Number, 10), strconv.FormatInt(*t.Number, 10), t.OriginHost, p.DestinationHost, p.RemoteIP, "down").Set(0)
+					state.WithLabelValues(strconv.FormatInt(*p.Number, 10), strconv.FormatInt(*t.Number, 10), t.OriginHost, p.DestinationHost, p.RemoteIP, "initial").Set(1)
 				}
 
 				// receive stats
-				recvCnt.WithLabelValues(strconv.FormatInt(*t.Number, 10), t.OriginHost, p.DestinationHost, p.RemoteIP).Set(float64(p.Statistics.ReceiveCnt))
-				recvAvg.WithLabelValues(strconv.FormatInt(*t.Number, 10), t.OriginHost, p.DestinationHost, p.RemoteIP).Set(float64(p.Statistics.ReceiveAvg))
-				recvMax.WithLabelValues(strconv.FormatInt(*t.Number, 10), t.OriginHost, p.DestinationHost, p.RemoteIP).Set(float64(p.Statistics.ReceiveMax))
-				recvOct.WithLabelValues(strconv.FormatInt(*t.Number, 10), t.OriginHost, p.DestinationHost, p.RemoteIP).Set(float64(p.Statistics.ReceiveOct))
-				recvDvi.WithLabelValues(strconv.FormatInt(*t.Number, 10), t.OriginHost, p.DestinationHost, p.RemoteIP).Set(float64(p.Statistics.ReceiveDvi))
-				sendAvg.WithLabelValues(strconv.FormatInt(*t.Number, 10), t.OriginHost, p.DestinationHost, p.RemoteIP).Set(float64(p.Statistics.SendAvg))
-				sendCnt.WithLabelValues(strconv.FormatInt(*t.Number, 10), t.OriginHost, p.DestinationHost, p.RemoteIP).Set(float64(p.Statistics.SendCnt))
-				sendPend.WithLabelValues(strconv.FormatInt(*t.Number, 10), t.OriginHost, p.DestinationHost, p.RemoteIP).Set(float64(p.Statistics.SendPending))
-				sendMax.WithLabelValues(strconv.FormatInt(*t.Number, 10), t.OriginHost, p.DestinationHost, p.RemoteIP).Set(float64(p.Statistics.SendMax))
-				sendOct.WithLabelValues(strconv.FormatInt(*t.Number, 10), t.OriginHost, p.DestinationHost, p.RemoteIP).Set(float64(p.Statistics.SendOct))
+				recvCnt.WithLabelValues(strconv.FormatInt(*p.Number, 10), strconv.FormatInt(*t.Number, 10), t.OriginHost, p.DestinationHost, p.RemoteIP).Set(float64(p.Statistics.ReceiveCnt))
+				recvAvg.WithLabelValues(strconv.FormatInt(*p.Number, 10), strconv.FormatInt(*t.Number, 10), t.OriginHost, p.DestinationHost, p.RemoteIP).Set(float64(p.Statistics.ReceiveAvg))
+				recvMax.WithLabelValues(strconv.FormatInt(*p.Number, 10), strconv.FormatInt(*t.Number, 10), t.OriginHost, p.DestinationHost, p.RemoteIP).Set(float64(p.Statistics.ReceiveMax))
+				recvOct.WithLabelValues(strconv.FormatInt(*p.Number, 10), strconv.FormatInt(*t.Number, 10), t.OriginHost, p.DestinationHost, p.RemoteIP).Set(float64(p.Statistics.ReceiveOct))
+				recvDvi.WithLabelValues(strconv.FormatInt(*p.Number, 10), strconv.FormatInt(*t.Number, 10), t.OriginHost, p.DestinationHost, p.RemoteIP).Set(float64(p.Statistics.ReceiveDvi))
+				sendAvg.WithLabelValues(strconv.FormatInt(*p.Number, 10), strconv.FormatInt(*t.Number, 10), t.OriginHost, p.DestinationHost, p.RemoteIP).Set(float64(p.Statistics.SendAvg))
+				sendCnt.WithLabelValues(strconv.FormatInt(*p.Number, 10), strconv.FormatInt(*t.Number, 10), t.OriginHost, p.DestinationHost, p.RemoteIP).Set(float64(p.Statistics.SendCnt))
+				sendPend.WithLabelValues(strconv.FormatInt(*p.Number, 10), strconv.FormatInt(*t.Number, 10), t.OriginHost, p.DestinationHost, p.RemoteIP).Set(float64(p.Statistics.SendPending))
+				sendMax.WithLabelValues(strconv.FormatInt(*p.Number, 10), strconv.FormatInt(*t.Number, 10), t.OriginHost, p.DestinationHost, p.RemoteIP).Set(float64(p.Statistics.SendMax))
+				sendOct.WithLabelValues(strconv.FormatInt(*p.Number, 10), strconv.FormatInt(*t.Number, 10), t.OriginHost, p.DestinationHost, p.RemoteIP).Set(float64(p.Statistics.SendOct))
 			}
 		}
 	}


### PR DESCRIPTION
append CurrentPeer to Peers if new peer is detected and CurrentPeer was already properly defined

CurrentPeer will otherwise be overwritten and only a single peer will work, with this approach all peers will be properly added

also added label for peer number to prometheus metrics